### PR TITLE
fix(just): explicitely source dotenv in local recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -45,7 +45,7 @@ run: build
 
 # Run the local development server
 local:
-    pnpm dev
+    set -a && source .env && set +a && pnpm dev
 
 # For debugging the environment variable
 check-env:


### PR DESCRIPTION
Explicitely source .env when running `just local` to avoid issues when used in conjunction with `just dev`.